### PR TITLE
Add screen sharing functionality

### DIFF
--- a/Web/amazon-connect-ccp-web-calling-example/package-lock.json
+++ b/Web/amazon-connect-ccp-web-calling-example/package-lock.json
@@ -8,12 +8,33 @@
       "name": "web-calling",
       "version": "1.0.0",
       "dependencies": {
-        "amazon-chime-sdk-js": "^3.18.2",
-        "amazon-connect-streams": "^2.10.0"
+        "amazon-chime-sdk-js": "^3.26.0",
+        "amazon-connect-streams": "^2.18.0"
       },
       "devDependencies": {
         "esbuild": "^0.19.10",
         "esbuild-plugins-node-modules-polyfill": "^1.6.1"
+      }
+    },
+    "node_modules/@amazon-connect/core": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@amazon-connect/core/-/core-1.0.4.tgz",
+      "integrity": "sha512-OrPy014zroeZ82BkavFRHKNFxtBR9bmUbNRDBm3GrBAUVI4CxsfHXAkRDxaKNNaj28E4ps8f50HLmrAtTlMUiQ=="
+    },
+    "node_modules/@amazon-connect/site": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@amazon-connect/site/-/site-1.0.4.tgz",
+      "integrity": "sha512-8TJTpU2mM4W6a/cv5NhUU0QYueko28ErGIu2DGWgfvUrwkcTnm2ODZuwnzXJaUXLHQu+FNEUe0yaXfvDbPQWkw==",
+      "dependencies": {
+        "@amazon-connect/core": "1.0.4"
+      }
+    },
+    "node_modules/@amazon-connect/site-streams": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@amazon-connect/site-streams/-/site-streams-1.0.4.tgz",
+      "integrity": "sha512-WWN8L9FQgcYiCN8Y0SrcrnwrgX7WWjtYARxwigswYDjppERNddm+4LbIYlQVEudJFzqHsW2hvi7XvwtSLdobKQ==",
+      "dependencies": {
+        "@amazon-connect/site": "1.0.4"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2012,11 +2033,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@types/node": {
-      "version": "20.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
-      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/ua-parser-js": {
@@ -2025,9 +2046,9 @@
       "integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg=="
     },
     "node_modules/amazon-chime-sdk-js": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.18.2.tgz",
-      "integrity": "sha512-w0O/X8NG+i7y6hS+iQOH0Yn1szkfFDyJDrFTtuZ81Ygd6832Ht1MLmNFf5HuaQzhqVve48W/fAtfcRYOcavIeg==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/amazon-chime-sdk-js/-/amazon-chime-sdk-js-3.26.0.tgz",
+      "integrity": "sha512-6VV2SS3Qc5LI4WgE3KLSJPTrG8iIHtC/Mr2PjufYgoYq2kD/6SWA9ya4j/j4aHe471n0pArRUSRdTQc754HCSw==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",
         "@aws-sdk/client-chime-sdk-messaging": "^3.341.0",
@@ -2035,19 +2056,24 @@
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
         "pako": "^2.0.4",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.3.0",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^1.0.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^15 || ^16 || ^18 || ^19",
-        "npm": "^6 || ^7 || ^8 || ^9"
+        "node": "^18 || ^19 || ^20 || ^22",
+        "npm": "^8 || ^9 || ^10"
       }
     },
     "node_modules/amazon-connect-streams": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/amazon-connect-streams/-/amazon-connect-streams-2.11.0.tgz",
-      "integrity": "sha512-GdaWItZYp/q44UnYa3aNEjQY952EwYqyTOiGwv+3ckqq+Zx1ek64UlxE39q4WRRsqosLe66rFKovTzkGRrrHOw==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/amazon-connect-streams/-/amazon-connect-streams-2.18.0.tgz",
+      "integrity": "sha512-EpYNp5EvB7K2l/GrBK0yNnd2mcfr8+ivcgHW3jenLkXfVpqF0FGCpeaO0SU0SBWRNEqlvDnQQIgLTXRHw4xVzw==",
+      "dependencies": {
+        "@amazon-connect/core": "1.0.4",
+        "@amazon-connect/site": "1.0.4",
+        "@amazon-connect/site-streams": "1.0.4"
+      },
       "engines": {
         "node": ">=12.0.0"
       }
@@ -2161,9 +2187,9 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -2230,9 +2256,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/Web/amazon-connect-ccp-web-calling-example/package.json
+++ b/Web/amazon-connect-ccp-web-calling-example/package.json
@@ -6,8 +6,8 @@
     "start": "node esbuild.mjs --watch"
   },
   "dependencies": {
-    "amazon-chime-sdk-js": "^3.18.2",
-    "amazon-connect-streams": "^2.10.0"
+    "amazon-chime-sdk-js": "^3.26.0",
+    "amazon-connect-streams": "^2.18.0"
   },
   "devDependencies": {
     "esbuild": "^0.19.10",

--- a/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/ControlBar/ControlBar.js
+++ b/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/ControlBar/ControlBar.js
@@ -5,6 +5,8 @@ import contactManager from '../../../../../services/ContactManager.js';
 import './VideoButton/VideoButton.js';
 import './MicButton/MicButton.js';
 import './HangUpButton/HangUpButton.js';
+import './ScreenSharingSessionButton/ScreenSharingSessionButton.js';
+import './ScreenShareButton/ScreenShareButton.js';
 import './EndContactButton/EndContactButton.js';
 
 class ControlBar extends HTMLElement {
@@ -45,6 +47,8 @@ class ControlBar extends HTMLElement {
             ? `
               <mic-button></mic-button>
               ${contactManager.shouldRenderLocalVideo() ? '<video-button></video-button>' : ''}
+              <screen-sharing-session-button></screen-sharing-session-button>
+              <screen-share-button></screen-share-button>
               <hang-up-button></hang-up-button>`
             : '<end-contact-button></end-contact-button>'
         }

--- a/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/ControlBar/MicButton/MicButton.js
+++ b/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/ControlBar/MicButton/MicButton.js
@@ -38,7 +38,7 @@ class MicButton extends HTMLElement {
   }
 
   updateLabel() {
-    this.micButton.textContent = this.isMuted ? 'Unmute mic' : 'Mute mic';
+    this.micButton.textContent = this.isMuted ? 'Unmute' : 'Mute';
   }
 
   render() {
@@ -49,8 +49,9 @@ class MicButton extends HTMLElement {
         }
       </style>
 
-      <button id="mic-button" >Mute mic</button>
+      <button id="mic-button" ></button>
     `;
+    this.updateLabel();
   }
 }
 

--- a/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/ControlBar/ScreenShareButton/ScreenShareButton.js
+++ b/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/ControlBar/ScreenShareButton/ScreenShareButton.js
@@ -1,0 +1,58 @@
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: MIT-0
+
+import contactManager from '../../../../../../services/ContactManager';
+import eventBus from '../../../../../../utils/EventBus';
+
+class ScreenShareButton extends HTMLElement {
+  constructor() {
+    super();
+    this.label = 'Share screen';
+  }
+
+  get screenShareButton() {
+    return this.querySelector('#screen-share-button');
+  }
+
+  connectedCallback() {
+    this.render();
+    eventBus.on('ScreenSharingStateChanged', () => {
+      this.updateStyles();
+      this.updateLabel();
+    });
+  }
+
+  attachEvents() {
+    this.screenShareButton.addEventListener('click', async () => {
+      await contactManager.toggleScreenShare();
+      this.updateLabel();
+    });
+  }
+
+  updateLabel() {
+    this.label = contactManager.isLocalUserSharing ? 'Stop share' : 'Share screen';
+    this.screenShareButton.innerHTML = this.label;
+  }
+
+  updateStyles() {
+    this.style.display = contactManager.isScreenSharingSessionStarted ? 'inline-block' : 'none';
+  }
+
+  render() {
+    this.innerHTML = `
+      <style>
+        #screen-share-button {
+          height: 50px;
+        }
+      </style>
+
+      <button id="screen-share-button" >
+        ${this.label}
+      </button>
+    `;
+    this.attachEvents();
+    this.updateStyles();
+  }
+}
+
+customElements.define('screen-share-button', ScreenShareButton);

--- a/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/ControlBar/ScreenSharingSessionButton/ScreenSharingSessionButton.js
+++ b/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/ControlBar/ScreenSharingSessionButton/ScreenSharingSessionButton.js
@@ -1,0 +1,46 @@
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: MIT-0
+
+import contactManager from '../../../../../../services/ContactManager';
+import eventBus from '../../../../../../utils/EventBus';
+
+class ScreenSharingSessionButton extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  get screenShareButton() {
+    return this.querySelector('#screen-sharing-session-button');
+  }
+
+  connectedCallback() {
+    this.render();
+
+    eventBus.on('ScreenSharingStateChanged', () => {
+      this.render();
+    });
+  }
+
+  attachEvents() {
+    this.screenShareButton.addEventListener('click', async () => {
+      await contactManager.toggleScreenSharingSession();
+    });
+  }
+
+  render() {
+    this.innerHTML = `
+      <style>
+        #screen-sharing-session-button {
+          height: 50px;
+        }
+      </style>
+
+      <button id="screen-sharing-session-button">
+        ${contactManager.isScreenSharingSessionStarted ? 'End sharing session' : 'Start sharing session'}
+      </button>
+    `;
+    this.attachEvents();
+  }
+}
+
+customElements.define('screen-sharing-session-button', ScreenSharingSessionButton);

--- a/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/ControlBar/VideoButton/VideoButton.js
+++ b/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/ControlBar/VideoButton/VideoButton.js
@@ -6,7 +6,7 @@ import contactManager from '../../../../../../services/ContactManager';
 class VideoButton extends HTMLElement {
   constructor() {
     super();
-    this.label = 'Turn on video';
+    this.label = 'Start video';
   }
 
   get videoButton() {
@@ -26,7 +26,7 @@ class VideoButton extends HTMLElement {
   }
 
   updateLabel() {
-    this.label = this.label === 'Turn on video' ? 'Turn off video' : 'Turn on video';
+    this.label = this.label === 'Start video' ? 'Stop video' : 'Start video';
     this.videoButton.innerHTML = this.label;
   }
 

--- a/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/VideoTileGrid/LocalVideo/LocalVideo.js
+++ b/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/VideoTileGrid/LocalVideo/LocalVideo.js
@@ -2,6 +2,7 @@
 //  SPDX-License-Identifier: MIT-0
 
 import contactManager from '../../../../../../services/ContactManager';
+import eventBus from '../../../../../../utils/EventBus';
 
 class LocalVideo extends HTMLElement {
   constructor() {
@@ -15,26 +16,44 @@ class LocalVideo extends HTMLElement {
   connectedCallback() {
     this.render();
     contactManager.subscribeToLocalVideo(this.localVideo);
+
+    eventBus.on('ScreenSharingStateChanged', () => {
+      this.updateStyles();
+    });
+  }
+
+  updateStyles() {
+    this.localVideo.className = contactManager.isScreenSharingSessionStarted ? 'screen-sharing-on' : 'screen-sharing-off';
   }
 
   render() {
     this.innerHTML = `
       <style>
         #local-video {
-          height: 150px;
-          width: 100px;
           object-fit: cover;
           background-color: black;
-          position: absolute;  
+          position: absolute;
+          border: 1px solid white;
+          box-sizing: border-box;
+        }
+        #local-video.screen-sharing-off {
+          height: 150px;
+          width: 100px;
           top: 10px;
           right: 10px;
-          border: 1px solid white;
           border-radius: 5px;
         }
+        #local-video.screen-sharing-on {
+          height: 100px;
+          width: 200px;
+          top: 0px;
+          right: 0px;
+          border-radius: 0;
+        }
       </style>
-
-      <video id="local-video" ></video>
+      <video id="local-video"></video>
     `;
+    this.updateStyles();
   }
 }
 

--- a/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/VideoTileGrid/RemoteVideo/RemoteVideo.js
+++ b/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/VideoTileGrid/RemoteVideo/RemoteVideo.js
@@ -2,6 +2,7 @@
 //  SPDX-License-Identifier: MIT-0
 
 import contactManager from '../../../../../../services/ContactManager';
+import eventBus from '../../../../../../utils/EventBus';
 
 class RemoteVideo extends HTMLElement {
   constructor() {
@@ -15,21 +16,43 @@ class RemoteVideo extends HTMLElement {
   connectedCallback() {
     this.render();
     contactManager.subscribeToRemoteVideo(this.remoteVideo);
+
+    eventBus.on('ScreenSharingStateChanged', () => {
+      this.updateStyles();
+    });
+  }
+
+  updateStyles() {
+    this.remoteVideo.className = contactManager.isScreenSharingSessionStarted ? 'screen-sharing-on' : 'screen-sharing-off';
   }
 
   render() {
     this.innerHTML = `
       <style>
         #remote-video {
+          object-fit: cover;
+          background-color: black;
+          box-sizing: border-box;
+        }
+        #remote-video.screen-sharing-off {
           height: 400px;
           width: 400px;
           object-fit: cover;
           background-color: black;
         }
+        #remote-video.screen-sharing-on {
+          height: 100px;
+          width: 200px;
+          top: 0px;
+          left: 0px;
+          border: 1px solid white;
+          border-radius: 0;
+          position: absolute;
+        }
       </style>
-
-      <video id="remote-video" ></video>
+      <video id="remote-video"></video>
     `;
+    this.updateStyles();
   }
 }
 

--- a/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/VideoTileGrid/ScreenShare/ScreenShare.js
+++ b/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/VideoTileGrid/ScreenShare/ScreenShare.js
@@ -1,0 +1,47 @@
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: MIT-0
+
+import contactManager from '../../../../../../services/ContactManager';
+import eventBus from '../../../../../../utils/EventBus';
+
+class ScreenShare extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  get screenShare() {
+    return this.querySelector('#screen-share');
+  }
+
+  connectedCallback() {
+    this.render();
+    contactManager.subscribeToScreenShare(this.screenShare);
+    eventBus.on('ScreenSharingStateChanged', () => {
+      this.updateStyles();
+    });
+  }
+
+  updateStyles() {
+    this.style.display = contactManager.isScreenSharingSessionStarted ? 'inline-block' : 'none';
+  }
+
+  render() {
+    this.innerHTML = `
+      <style>
+        #screen-share {
+          height: 300px;
+          width: 400px;
+          background-color: grey;
+          position: absolute;
+          top: 100px;
+          box-sizing: border-box;
+        }
+      </style>
+
+      <video id="screen-share"></video>
+    `;
+    this.updateStyles();
+  }
+}
+
+customElements.define('screen-share', ScreenShare);

--- a/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/VideoTileGrid/VideoTileGrid.js
+++ b/Web/amazon-connect-ccp-web-calling-example/src/components/MyCustomCCP/ConferenceView/DisplayPanel/VideoTileGrid/VideoTileGrid.js
@@ -2,8 +2,10 @@
 //  SPDX-License-Identifier: MIT-0
 
 import contactManager from '../../../../../services/ContactManager.js';
+import eventBus from '../../../../../utils/EventBus.js';
 import './LocalVideo/LocalVideo.js';
 import './RemoteVideo/RemoteVideo.js';
+import './ScreenShare/ScreenShare.js';
 
 class VideoTileGrid extends HTMLElement {
   constructor() {
@@ -26,8 +28,9 @@ class VideoTileGrid extends HTMLElement {
       </style>
 
       <div id="video-tile-grid" >
-      ${contactManager.shouldRenderLocalVideo() ? '<local-video></local-video>' : ''}
-      ${contactManager.shouldRenderRemoteVideo() ? '<remote-video></remote-video>' : ''}
+        ${contactManager.shouldRenderLocalVideo() ? '<local-video></local-video>' : ''}
+        ${contactManager.shouldRenderRemoteVideo() ? '<remote-video></remote-video>' : ''}
+        <screen-share></screen-share>
       </div>
     `;
   }


### PR DESCRIPTION
**Issue #:**

**Example:**

*What example(s) are you making change?*
- Web/amazon-connect-ccp-web-calling-example

**Description:**
*Please describe the change.*

- Add screen sharing functionality to demonstrate how to use stream JS and Chime SDK JS APIs to build an screen sharing experience.

**Testing:**

*Please provide reproducible step-by-step instructions.*

Verified e2e locally.
1. connect to a e2e call using OOTB widget.
2. agent start screen sharing session
3. verify video tile change and a new button for share screen appears
4. agent share screen and verify end user can view the screen

**Checklist:**

If it's CPP web calling example change: 
 1. Have you verified the change works in all [supporting broswers](https://docs.aws.amazon.com/connect/latest/adminguide/connect-supported-browsers.html)?

Yes

 2. Is integration tests change needed? If yes, please share the link for the change.

Not sure

If it's iOS in-app calling example change:
 1. Have you verified the change works in all [supporting iOS vesions](https://docs.aws.amazon.com/connect/latest/adminguide/connect-supported-browsers.html)?
 2. Is integration tests change needed? If yes, please share the link for the change.

If it's Android in-app calling example change:
 1. Have you verified the change works in all [supporting Android vesions](https://docs.aws.amazon.com/connect/latest/adminguide/connect-supported-browsers.html)?
 2. Is integration tests change needed? If yes, please share the link for the change.

If it's bankend api example change, have you verified both iOS/Android in-app calling examples are compatible with this change?