### PR TITLE
Resolve Android build warnings

### DIFF
--- a/Android/AmazonConnectInAppCallingAndroidSample/.gitignore
+++ b/Android/AmazonConnectInAppCallingAndroidSample/.gitignore
@@ -11,6 +11,8 @@ build/
 /libs
 **/build/
 !src/**/build/
+debug/
+release/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/CallSheet.kt
+++ b/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/CallSheet.kt
@@ -279,7 +279,7 @@ class CallSheet : BaseBottomSheetFragment() {
     }
 
     private fun updateScreenSharePanel() {
-        viewModel.screenShareStatus?.value.let{
+        viewModel.screenShareStatus.value.let{
             when(it) {
                 ScreenShareStatus.LOCAL -> {
                     controlPanel.updateScreenShareButtonHighlight(true)

--- a/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/CallSheetViewModel.kt
+++ b/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/CallSheetViewModel.kt
@@ -236,8 +236,8 @@ class CallSheetViewModel(
         _screenShareStatus.postValue(status)
     }
 
-    override fun onScreenShareTileStateChanged(tileStates: VideoTileState?) {
-        _screenShareTileState.postValue(tileStates)
+    override fun onScreenShareTileStateChanged(tileState: VideoTileState?) {
+        _screenShareTileState.postValue(tileState)
     }
 
     fun bindLocalScreenShareView(videoRenderView: VideoRenderView) {

--- a/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/screenshare/ScreenSharePanel.kt
+++ b/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/screenshare/ScreenSharePanel.kt
@@ -73,7 +73,7 @@ internal class ScreenSharePanel(
     }
 
     private fun updateSenderTextView() {
-        viewModel.screenShareStatus?.value.let{
+        viewModel.screenShareStatus.value.let{
             when(it) {
                 ScreenShareStatus.LOCAL -> {
                     senderTextView.setText(R.string.call_sheet_screen_share_local_sender)

--- a/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/utils/ViewModelFactory.kt
+++ b/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/utils/ViewModelFactory.kt
@@ -19,6 +19,7 @@ internal class ViewModelFactory(
     private val callManager: CallManager,
     private val callStateRepository: CallStateRepository
     ) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T = with(modelClass) {
         when {
             isAssignableFrom(CallSheetViewModel::class.java) ->


### PR DESCRIPTION
**Issue #:** N/A

**Example:** Android/AmazonConnectInAppCallingAndroidSample

**Description:**
This PR addresses 7 Kotlin compiler warnings in the Android in-app calling example:

1. Removed unnecessary safe call operators on non-null LiveData receivers in CallSheet.kt and ScreenSharePanel.kt
2. Fixed parameter name mismatch in CallSheetViewModel.kt to align with the interface definition
3. Replaced deprecated getColor() method calls with ContextCompat.getColor() in DTMFSheet.kt
4. Replaced deprecated SOFT_INPUT_ADJUST_RESIZE flag with modern WindowInsetsController API
5. Added Suppress annotation for the unchecked cast in ViewModelFactory.kt

## Warning Details and Fixes

### 1 & 2: Unnecessary Safe Call on Non-Null LiveData Receiver (CallSheet.kt and ScreenSharePanel.kt)
```
Unnecessary safe call on a non-null receiver of type LiveData<ScreenShareStatus>
```
**Fix:** Removed the unnecessary safe call operator (`?.`) since LiveData objects are guaranteed to be non-null:
```kotlin
// Before
viewModel.screenShareStatus?.value.let{
// After
viewModel.screenShareStatus.value.let{
```

### 3: Parameter Name Mismatch in CallSheetViewModel.kt
```
The corresponding parameter in the supertype 'CallObserver' is named 'tileState'. 
This may cause problems when calling this function with named arguments.
```
**Fix:** Aligned the parameter name in the implementation with the interface definition:
```kotlin
// Before
override fun onScreenShareTileStateChanged(tileStates: VideoTileState?) {
// After
override fun onScreenShareTileStateChanged(tileState: VideoTileState?) {
```

### 4 & 5: Deprecated getColor() Method in DTMFSheet.kt
```
'getColor(Int): Int' is deprecated. Deprecated in Java
```
**Fix:** Replaced deprecated method with the recommended alternative from AndroidX:
```kotlin
// Before
getResources().getColor(R.color.dtmf_sent_message_text_green)
// After
ContextCompat.getColor(requireContext(), R.color.dtmf_sent_message_text_green)
```

### 6: Deprecated SOFT_INPUT_ADJUST_RESIZE Flag
```
'SOFT_INPUT_ADJUST_RESIZE: Int' is deprecated. Deprecated in Java
```
**Fix:** Replaced deprecated window input mode with the modern approach using WindowInsetsController, based on the solution from [this Stack Overflow thread](https://stackoverflow.com/questions/68003131/soft-input-adjust-resize-deprecated-starting-android-30):
```kotlin
// Before
dialog?.getWindow()?.setSoftInputMode(SOFT_INPUT_STATE_VISIBLE or WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
// After
if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
    // Use the new API for Android 30 (API R) and above
    requireDialog().window?.let { window ->
        WindowCompat.setDecorFitsSystemWindows(window, false)
        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { _, insets ->
            val imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
            val navigationBarHeight = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
            view.setPadding(0, 0, 0, imeHeight - navigationBarHeight)
            insets
        }

        val controller = WindowInsetsControllerCompat(window, window.decorView)
        controller.show(WindowInsetsCompat.Type.ime())
    }
} else {
    // Use the legacy API for Android below 30
    @Suppress("DEPRECATION")
    dialog?.window?.setSoftInputMode(SOFT_INPUT_STATE_VISIBLE or WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
}
```

### 7: Unchecked Cast in ViewModelFactory.kt
```
Unchecked cast: ViewModel to T
```
**Fix:** Added a suppression annotation to acknowledge the intentional unchecked cast:
```kotlin
@Suppress("UNCHECKED_CAST")
override fun <T : ViewModel> create(modelClass: Class<T>): T = with(modelClass) {
    when {
        // Implementation remains the same
    } as T
}
```
Since this is a demo application repository, I think using a suppression annotation is an appropriate solution.

## Additional Notes

There are two remaining warnings in CallSheet.kt regarding unused parameters:
```
Parameter 'screenShareStatus' is never used
Parameter 'tileState' is never used
```
These warnings are false positives. The parameters in the Observer pattern implementation are correctly utilized indirectly, so no changes are required.

## Build Results

### Before:
```text
> Task :app:compileDebugKotlin
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/CallSheet.kt:273:47 Parameter 'screenShareStatus' is never used
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/CallSheet.kt:277:50 Parameter 'tileState' is never used
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/CallSheet.kt:282:36 Unnecessary safe call on a non-null receiver of type LiveData<ScreenShareStatus>
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/CallSheetViewModel.kt:239:48 The corresponding parameter in the supertype 'CallObserver' is named 'tileState'. This may cause problems when calling this function with named arguments.
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/dtmf/DTMFSheet.kt:66:74 'getColor(Int): Int' is deprecated. Deprecated in Java
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/dtmf/DTMFSheet.kt:75:74 'getColor(Int): Int' is deprecated. Deprecated in Java
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/dtmf/DTMFSheet.kt:99:102 'SOFT_INPUT_ADJUST_RESIZE: Int' is deprecated. Deprecated in Java
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/screenshare/ScreenSharePanel.kt:76:36 Unnecessary safe call on a non-null receiver of type LiveData<ScreenShareStatus>
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/utils/ViewModelFactory.kt:37:7 Unchecked cast: ViewModel to T
```

### After:
```text
> Task :app:compileDebugKotlin
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/CallSheet.kt:273:47 Parameter 'screenShareStatus' is never used
w: file:///C:/Users/inoue/amazon-connect-in-app-calling-examples/Android/AmazonConnectInAppCallingAndroidSample/app/src/main/java/com/amazonaws/services/connect/inappcalling/sample/ui/CallSheet.kt:277:50 Parameter 'tileState' is never used
```

**Testing:**

1. Clone the repository and checkout this branch
2. Open the Android project in Android Studio
3. Build the project and verify that the warnings are reduced from 9 to just 2 false positives
4. Run the application and test the functionality (I tested on AWS Device Farm):
   - Test DTMF input (verify keyboard shows correctly)
   - Test screen sharing
   - Test view model creation
   - Verify all other functionality works as expected

**Checklist:**

If it's CPP web calling example change:
 1. Have you verified the change works in all [supporting broswers](https://docs.aws.amazon.com/connect/latest/adminguide/connect-supported-browsers.html)?

    N/A

 2. Is integration tests chnage needed? If yes, please share the link for the change.

    N/A

If it's iOS in-app calling example change:
 1. Have you verified the change works in all [supporting iOS vesions](https://docs.aws.amazon.com/connect/latest/adminguide/connect-supported-browsers.html)?

    N/A

 2. Is integration tests change needed? If yes, please share the link for the change.

    N/A

If it's Android in-app calling example change:
 1. Have you verified the change works in all [supporting Android vesions](https://docs.aws.amazon.com/connect/latest/adminguide/connect-supported-browsers.html)?

    Yes

 2. Is integration tests change needed? If yes, please share the link for the change.

    No, these changes are purely to fix compiler warnings and do not affect functionality.

If it's bankend api example change, have you verified both iOS/Android in-app calling examples are compatible with this change? N/A